### PR TITLE
simplify usage across IDE's and operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ During the training participants will be asked to run the Flink job `TroubledStr
 
 ### Locally
 
-Just run the main-method of `TroubledStreamingJob`. When using IntelliJ IDEA, make sure to check `include dependencies with "Provided" scope` in the "Run Configuration". To access the Flink UI, replace the existing `ExecutionEnvironment` by `StreamExecutionEnvironment.createLocalEnvironmentWithWebUi(new Configuration())`. You might also want to use `DataStream#print()` instead of the `DiscardingSink` for local debugging.
+Just run the single test `TroubledStreamingJobRunner` which will call main with a local configuration and automatically pulls in dependencies with "Provided" scope. 
 
 ### dA Platform
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ During the training participants will be asked to run the Flink job `TroubledStr
 
 ### Locally
 
-Just run the single test `TroubledStreamingJobRunner` which will call main with a local configuration and automatically pulls in dependencies with "Provided" scope. 
+Just run the single test `TroubledStreamingJobRunner` which will call the main-method of TroubledStreamingJob with a local configuration and automatically pull in dependencies with "Provided" scope.
 
 ### dA Platform
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com.dataartisans.training/TroubledStreamingJobRunner.java
+++ b/src/test/java/com.dataartisans.training/TroubledStreamingJobRunner.java
@@ -6,7 +6,7 @@ public class TroubledStreamingJobRunner {
 
     @Test
     public void run() throws Exception {
-        String[] args = {"--test", "true"};
+        String[] args = {"--local", "true"};
         TroubledStreamingJob.main(args);
     }
 }

--- a/src/test/java/com.dataartisans.training/TroubledStreamingJobRunner.java
+++ b/src/test/java/com.dataartisans.training/TroubledStreamingJobRunner.java
@@ -1,0 +1,12 @@
+package com.dataartisans.training;
+
+import org.junit.Test;
+
+public class TroubledStreamingJobRunner {
+
+    @Test
+    public void run() throws Exception {
+        String[] args = {"--test", "true"};
+        TroubledStreamingJob.main(args);
+    }
+}


### PR DESCRIPTION
Simplifies usage of the training exercise by call main from a test which automatically pulls in provided dependencies. This removes the need to have different configurations for different IDE's or requiring participants to change the pom file themselves. 