### PR TITLE
add TroubledStreamingJobSolution41a with a different order of solving issues to get to solution 42

### DIFF
--- a/src/main/java/com/ververica/flinktraining/exercises/troubleshoot/ObjectReuseJob.java
+++ b/src/main/java/com/ververica/flinktraining/exercises/troubleshoot/ObjectReuseJob.java
@@ -49,11 +49,11 @@ public class ObjectReuseJob {
 
         final OutputTag<ExtendedMeasurement> temperatureTag =
                 new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
+                    private static final long serialVersionUID = 1L;
                 };
         final OutputTag<ExtendedMeasurement> windTag =
                 new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
+                    private static final long serialVersionUID = 1L;
                 };
 
         SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env

--- a/src/main/java/com/ververica/flinktraining/exercises/troubleshoot/TroubledStreamingJob.java
+++ b/src/main/java/com/ververica/flinktraining/exercises/troubleshoot/TroubledStreamingJob.java
@@ -57,7 +57,7 @@ public class TroubledStreamingJob {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/provided/troubleshoot/FakeKafkaSource.java
+++ b/src/main/java/com/ververica/flinktraining/provided/troubleshoot/FakeKafkaSource.java
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
  */
 @DoNotChangeThis
 public class FakeKafkaSource extends RichParallelSourceFunction<FakeKafkaRecord> implements CheckpointedFunction {
-    private static final long serialVersionUID = 4658785571367840693L;
+    private static final long serialVersionUID = 1L;
 
     private static final int    NO_OF_PARTIONS = 8;
     public static final  Logger log            = LoggerFactory.getLogger(FakeKafkaSource.class);

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/ObjectReuseJobSolution1.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/ObjectReuseJobSolution1.java
@@ -51,11 +51,11 @@ public class ObjectReuseJobSolution1 {
 
         final OutputTag<ExtendedMeasurement> temperatureTag =
                 new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
+                    private static final long serialVersionUID = 1L;
                 };
         final OutputTag<ExtendedMeasurement> windTag =
                 new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
+                    private static final long serialVersionUID = 1L;
                 };
 
         SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/ObjectReuseJobSolution2.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/ObjectReuseJobSolution2.java
@@ -54,11 +54,11 @@ public class ObjectReuseJobSolution2 {
 
         final OutputTag<ExtendedMeasurement> temperatureTag =
                 new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
+                    private static final long serialVersionUID = 1L;
                 };
         final OutputTag<ExtendedMeasurement> windTag =
                 new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
+                    private static final long serialVersionUID = 1L;
                 };
 
         SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution1.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution1.java
@@ -58,7 +58,7 @@ public class TroubledStreamingJobSolution1 {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution2.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution2.java
@@ -61,7 +61,7 @@ public class TroubledStreamingJobSolution2 {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution31.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution31.java
@@ -61,7 +61,7 @@ public class TroubledStreamingJobSolution31 {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution32.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution32.java
@@ -62,7 +62,7 @@ public class TroubledStreamingJobSolution32 {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution33.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution33.java
@@ -63,7 +63,7 @@ public class TroubledStreamingJobSolution33 {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41.java
@@ -63,7 +63,7 @@ public class TroubledStreamingJobSolution41 {
                 .uid("Deserialization");
 
         OutputTag<Measurement> lateDataTag = new OutputTag<Measurement>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
@@ -191,7 +191,7 @@ public class TroubledStreamingJobSolution41 {
 
     public static class MeasurementWindowAggregatingFunction
             implements AggregateFunction<Measurement, WindowedMeasurements, WindowedMeasurements> {
-        private static final long serialVersionUID = -1083906142198231377L;
+        private static final long serialVersionUID = 3L;
 
         public MeasurementWindowAggregatingFunction() {}
 

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41a.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41a.java
@@ -63,7 +63,7 @@ public class TroubledStreamingJobSolution41a {
                 .uid("Deserialization");
 
         OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41a.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution41a.java
@@ -1,0 +1,270 @@
+package com.ververica.flinktraining.solutions.troubleshoot;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flinktraining.provided.troubleshoot.FakeKafkaRecord;
+import com.ververica.flinktraining.provided.troubleshoot.WindowedMeasurements;
+import com.ververica.flinktraining.provided.troubleshoot.SourceUtils;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flinktraining.exercises.troubleshoot.TroubledStreamingJobUtils.createConfiguredEnvironment;
+
+public class TroubledStreamingJobSolution41a {
+
+    public static void main(String[] args) throws Exception {
+        ParameterTool parameters = ParameterTool.fromArgs(args);
+
+        final boolean local = parameters.getBoolean("local", false);
+
+        StreamExecutionEnvironment env = createConfiguredEnvironment(parameters, local);
+
+        //Time Characteristics
+        env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+        env.getConfig().setAutoWatermarkInterval(100);
+        env.setBufferTimeout(10);
+
+        //Checkpointing Configuration
+        env.enableCheckpointing(5000);
+        env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+        DataStream<JsonNode> sourceStream = env
+                .addSource(SourceUtils.createFakeKafkaSource())
+                .name("FakeKafkaSource")
+                .uid("FakeKafkaSource")
+                .assignTimestampsAndWatermarks(
+                        new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+                                Time.of(1, TimeUnit.SECONDS)))
+                .name("Watermarks")
+                .uid("Watermarks")
+                .flatMap(new MeasurementDeserializer())
+                .name("Deserialization")
+                .uid("Deserialization");
+
+        OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+            private static final long serialVersionUID = 33513631677208956L;
+        };
+
+        SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+                .keyBy(jsonNode -> jsonNode.get("location").asText())
+                .timeWindow(Time.of(1, TimeUnit.SECONDS))
+                .sideOutputLateData(lateDataTag)
+                .aggregate(new MeasurementWindowAggregatingFunction(),
+                        new MeasurementWindowProcessFunction())
+                .name("WindowedAggregationPerLocation")
+                .uid("WindowedAggregationPerLocation");
+
+        if (local) {
+            aggregatedPerLocation.print()
+                    .name("NormalOutput")
+                    .uid("NormalOutput")
+                    .disableChaining();
+            aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+                    .name("LateDataSink")
+                    .uid("LateDataSink")
+                    .disableChaining();
+        } else {
+            aggregatedPerLocation.addSink(new DiscardingSink<>())
+                    .name("NormalOutput")
+                    .uid("NormalOutput")
+                    .disableChaining();
+            aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+                    .name("LateDataSink")
+                    .uid("LateDataSink")
+                    .disableChaining();
+        }
+
+        env.execute(TroubledStreamingJobSolution41a.class.getSimpleName());
+    }
+
+    /**
+     * Deserializes the JSON Kafka message.
+     */
+    public static class MeasurementDeserializer extends RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+        private static final long serialVersionUID = 2L;
+
+        private Counter numInvalidRecords;
+        private transient ObjectMapper instance;
+
+        @Override
+        public void open(final Configuration parameters) throws Exception {
+            super.open(parameters);
+            numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+            instance = createObjectMapper();
+        }
+
+        @Override
+        public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+            final JsonNode node;
+            try {
+                node = deserialize(kafkaRecord.getValue());
+            } catch (IOException e) {
+                numInvalidRecords.inc();
+                return;
+            }
+            out.collect(node);
+        }
+
+        private JsonNode deserialize(final byte[] bytes) throws IOException {
+            return instance.readValue(bytes, JsonNode.class);
+        }
+    }
+
+    public static class MeasurementTSExtractor implements AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+        private static final long serialVersionUID = 2L;
+
+        private long currentMaxTimestamp;
+        private long lastEmittedWatermark = Long.MIN_VALUE;
+        private long lastRecordProcessingTime;
+
+        private final long maxOutOfOrderness;
+        private final long idleTimeout;
+
+        MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+            if (maxOutOfOrderness.toMilliseconds() < 0) {
+                throw new RuntimeException("Tried to set the maximum allowed " +
+                        "lateness to " + maxOutOfOrderness +
+                        ". This parameter cannot be negative.");
+            }
+
+            if (idleTimeout.toMilliseconds() < 0) {
+                throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+                        ". This parameter cannot be negative.");
+            }
+
+
+            this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+            this.idleTimeout = idleTimeout.toMilliseconds();
+            this.currentMaxTimestamp = Long.MIN_VALUE;
+        }
+
+        public long getMaxOutOfOrdernessInMillis() {
+            return maxOutOfOrderness;
+        }
+
+        @Override
+        public final Watermark getCurrentWatermark() {
+
+            // if last record was processed more than the idleTimeout in the past, consider this
+            // source idle and set timestamp to current processing time
+            long currentProcessingTime = System.currentTimeMillis();
+            if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+                this.currentMaxTimestamp = currentProcessingTime;
+            }
+
+            long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+            if (potentialWM >= lastEmittedWatermark) {
+                lastEmittedWatermark = potentialWM;
+            }
+            return new Watermark(lastEmittedWatermark);
+        }
+
+        @Override
+        public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+            lastRecordProcessingTime = System.currentTimeMillis();
+            long timestamp = element.getTimestamp();
+            if (timestamp > currentMaxTimestamp) {
+                currentMaxTimestamp = timestamp;
+            }
+            return timestamp;
+        }
+    }
+
+    public static class MeasurementWindowAggregatingFunction
+            implements AggregateFunction<JsonNode, WindowedMeasurements, WindowedMeasurements> {
+        private static final long serialVersionUID = 2L;
+
+        public MeasurementWindowAggregatingFunction() {}
+
+        @Override
+        public WindowedMeasurements createAccumulator() {
+            return new WindowedMeasurements();
+        }
+
+        @Override
+        public WindowedMeasurements add(final JsonNode record, final WindowedMeasurements aggregate) {
+            double result = Double.parseDouble(record.get("value").asText());
+            aggregate.setSumPerWindow(aggregate.getSumPerWindow() + result);
+            aggregate.setEventsPerWindow(aggregate.getEventsPerWindow() + 1);
+            return aggregate;
+        }
+
+        @Override
+        public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+            return windowedMeasurements;
+        }
+
+        @Override
+        public WindowedMeasurements merge(final WindowedMeasurements agg1, final WindowedMeasurements agg2) {
+            agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+            agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+            return agg2;
+        }
+    }
+
+    public static class MeasurementWindowProcessFunction
+            extends ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+        private static final long serialVersionUID = 1L;
+
+        private static final int    EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+        private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+        MeasurementWindowProcessFunction() {
+        }
+
+        @Override
+        public void process(
+                final String location,
+                final Context context,
+                final Iterable<WindowedMeasurements> input,
+                final Collector<WindowedMeasurements> out) {
+
+            // Windows with pre-aggregation only forward the final to the WindowFunction
+            WindowedMeasurements aggregate = input.iterator().next();
+
+            final TimeWindow window = context.window();
+            aggregate.setWindowStart(window.getStart());
+            aggregate.setWindowEnd(window.getEnd());
+            aggregate.setLocation(location);
+
+            eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+            out.collect(aggregate);
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+
+            eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+                    new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+        }
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution42.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution42.java
@@ -63,7 +63,7 @@ public class TroubledStreamingJobSolution42 {
                 .uid("Deserialization");
 
         OutputTag<Measurement> lateDataTag = new OutputTag<Measurement>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
@@ -193,7 +193,7 @@ public class TroubledStreamingJobSolution42 {
 
     public static class MeasurementWindowAggregatingFunction
             implements AggregateFunction<Measurement, WindowedMeasurements, WindowedMeasurements> {
-        private static final long serialVersionUID = -1083906142198231377L;
+        private static final long serialVersionUID = 3L;
 
         public MeasurementWindowAggregatingFunction() {}
 

--- a/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution43.java
+++ b/src/main/java/com/ververica/flinktraining/solutions/troubleshoot/TroubledStreamingJobSolution43.java
@@ -62,7 +62,7 @@ public class TroubledStreamingJobSolution43 {
                 .uid("Deserialization");
 
         OutputTag<SimpleMeasurement> lateDataTag = new OutputTag<SimpleMeasurement>("late-data") {
-            private static final long serialVersionUID = 33513631677208956L;
+            private static final long serialVersionUID = 1L;
         };
 
         SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
@@ -192,7 +192,7 @@ public class TroubledStreamingJobSolution43 {
 
     public static class MeasurementWindowAggregatingFunction
             implements AggregateFunction<SimpleMeasurement, WindowedMeasurements, WindowedMeasurements> {
-        private static final long serialVersionUID = -1083906142198231377L;
+        private static final long serialVersionUID = 3L;
 
         public MeasurementWindowAggregatingFunction() {}
 


### PR DESCRIPTION
This variant fixes the `ObjectMapper` initialization first, before changing the object type to a POJO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/flink-training-troubleshooting/4)
<!-- Reviewable:end -->
